### PR TITLE
global: Add character device creation

### DIFF
--- a/gpio_ctl.c
+++ b/gpio_ctl.c
@@ -1,22 +1,194 @@
-#include <linux/init.h>
+/**
+ * @file gpio_ctl.c
+ * @author your name (you@domain.com)
+ * @brief 
+ * @version 0.1
+ * @date 2022-03-10
+ *
+ * @copyright Copyright (c) 2022
+ *
+ */
+
 #include <linux/kernel.h>
 #include <linux/module.h>
+#include <linux/init.h>
+#include <linux/fs.h>
+#include <linux/cdev.h>
+#include <linux/slab.h>
+/**
+ * Kernel log level
+ * #include <linux/kern_levels.h>
+ */
+
+#include "gpio_ctl.h"
+#include "gpio_ctl_shared.h"
+
+#define cdrv_log(level, msg, ...) printk(KERN_##level "gpio_ctl driver: " msg , ##__VA_ARGS__)
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Joel Pinto");
 MODULE_DESCRIPTION("A custom GPIO controller driver");
 
-static int __init GpioCtlInit(void)
-{
-    printk(KERN_INFO "GPIOCTL LKM loaded\n");
+static int gpio_ctl_open(struct inode *inode, struct file *file);
+static int gpio_ctl_release(struct inode *, struct file *);
+static ssize_t gpio_ctl_read(struct file *file, char __user *buffer, size_t len, loff_t *offset);
+static ssize_t gpio_ctl_write(struct file *file, const char __user *buffer, size_t len, loff_t *offset);
+static long gpio_ctl_ioctl(struct file *file, unsigned int cmd, unsigned long param);
 
+// C tag struct initialization
+struct file_operations my_fops = {
+    .owner = THIS_MODULE,
+    .read = gpio_ctl_read,
+    .write = gpio_ctl_write,
+    .unlocked_ioctl = gpio_ctl_ioctl,
+    .open = gpio_ctl_open,
+    .release = gpio_ctl_release
+};
+
+static struct gpio_ctl_priv gpio_priv;
+
+/**
+ * @brief
+ *
+ * @param inode
+ * @param file
+ * @return int
+ */
+static int gpio_ctl_open(struct inode *inode, struct file *file)
+{
+    cdrv_log(INFO, "open\n");
     return 0;
 }
 
-static void __exit GpioCtlExit(void)
+/**
+ * @brief
+ *
+ * @return int
+ */
+static int gpio_ctl_release(struct inode *inode, struct file *file)
 {
-    printk(KERN_INFO "GPIO LKM unloaded\n");
+    cdrv_log(INFO, "release\n");
+    return 0;
 }
 
-module_init(GpioCtlInit);
-module_exit(GpioCtlExit);
+/**
+ * @brief
+ *
+ * @param file
+ * @param buffer
+ * @param len
+ * @param offset
+ * @return ssize_t
+ */
+static ssize_t gpio_ctl_read(struct file *file, char __user *buffer, size_t len, loff_t *offset)
+{
+    cdrv_log(INFO, "read\n");
+    return 0;
+}
+
+/**
+ * @brief
+ *
+ * @param file
+ * @param buffer
+ * @param len
+ * @param offset
+ * @return ssize_t
+ */
+static ssize_t gpio_ctl_write(struct file *file, const char __user *buffer, size_t len, loff_t *offset)
+{
+    cdrv_log(INFO, "write\n");
+    return 1;
+}
+
+/**
+ * @brief
+ *
+ * @param file
+ * @param cmd
+ * @param param
+ * @return long
+ */
+static long gpio_ctl_ioctl(struct file *file, unsigned int cmd, unsigned long param)
+{
+    return 0;
+}
+
+/**
+ * @brief
+ *
+ * @return int
+ */
+static int __init gpio_ctl_init(void)
+{
+    int ret;
+
+    cdrv_log(INFO,"Loading module \n");
+
+    /** Static device number allocation.
+     * @TODO - should be updated to dynamic allocation in the future.*/
+    gpio_priv.my_dev_num = MKDEV(GPIO_CTL_MAJOR, GPIO_CTL_MINOR);
+    ret = register_chrdev_region(gpio_priv.my_dev_num, GPIO_CTL_DEV_COUNT, GPIO_CTL_NAME);
+    if (ret < 0) {
+        cdrv_log(WARNING, "Failed to allocate device number, error code %d\n", ret);
+        goto failed_register_chrdev;
+    }
+
+    gpio_priv.my_cdev = cdev_alloc();
+    if (gpio_priv.my_cdev == NULL) {
+        cdrv_log(WARNING, "Failed to allocate cdev structure\n");
+        ret = -ENOMEM;
+        goto failed_cdev_alloc;
+    }
+    gpio_priv.my_cdev->owner = THIS_MODULE;
+    gpio_priv.my_cdev->ops = &my_fops;
+
+    /* Add c dev node to the system - /dev */
+    ret = cdev_add(gpio_priv.my_cdev, gpio_priv.my_dev_num, GPIO_CTL_DEV_COUNT);
+    if (ret < 0) {
+        cdrv_log(WARNING, "Failed to propagate the char dev to the system, error code %d\n", ret);
+        goto failed_cdev_add;
+    }
+
+    gpio_priv.my_class = class_create(THIS_MODULE, GPIO_CTL_NAME);
+    if (IS_ERR(gpio_priv.my_class)) {
+        ret = (int) PTR_ERR(gpio_priv.my_class);
+        cdrv_log(WARNING, "Failed to create class, error %d\n", ret);
+        goto failed_cdev_add;
+    }
+
+    gpio_priv.my_device = device_create(gpio_priv.my_class, NULL, gpio_priv.my_dev_num, NULL, GPIO_CTL_NAME);
+    if (IS_ERR(gpio_priv.my_device)) {
+        ret = (int) PTR_ERR(gpio_priv.my_device);
+        cdrv_log(WARNING, "Failed to create device, error code %d \n", ret);
+        goto failed_device_create;
+    }
+
+    return 0;
+
+failed_device_create:
+    device_destroy(gpio_priv.my_class, gpio_priv.my_dev_num);
+failed_cdev_add:
+    cdev_del(gpio_priv.my_cdev);
+failed_cdev_alloc:
+    unregister_chrdev_region(gpio_priv.my_dev_num, GPIO_CTL_DEV_COUNT);
+failed_register_chrdev:
+    return ret;
+}
+
+/**
+ * @brief
+ *
+ */
+static void __exit gpio_init_exit(void)
+{
+    cdrv_log(INFO, "Unloading gpio_ctl module\n");
+
+    device_destroy(gpio_priv.my_class, gpio_priv.my_dev_num);
+    class_destroy(gpio_priv.my_class);
+    cdev_del(gpio_priv.my_cdev);
+    unregister_chrdev_region(gpio_priv.my_dev_num, GPIO_CTL_DEV_COUNT);
+}
+
+module_init(gpio_ctl_init);
+module_exit(gpio_init_exit);

--- a/gpio_ctl.h
+++ b/gpio_ctl.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define GPIO_CTL_MINOR     0
+#define GPIO_CTL_DEV_COUNT 1
+
+struct gpio_ctl_priv {
+    dev_t my_dev_num;
+    struct cdev *my_cdev;
+    struct class *my_class;
+    struct device *my_device;
+};

--- a/gpio_ctl_shared.h
+++ b/gpio_ctl_shared.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define GPIO_CTL_NAME  "gpio_ctl_chr"
+// Confirm major availability
+#define GPIO_CTL_MAJOR 155 
+#define GPIO_CTL_MINOR 0


### PR DESCRIPTION
This commit implements the creation and disponibility of the gpio_ctl character device.
The device shall be used to serve as communication bridge between user and kernel address space
for the custom control of gpios.
Moreover, this commit also defines the an initial set of file operation registered for the
char device driver and also a logging macro which wraps an identifier to ease dmesg log analysis

Signed-off-by: Joel Pinto <joelpostman97@gmail.com>